### PR TITLE
feat: Convert CSS properties without selectors

### DIFF
--- a/src/utils/converter.ts
+++ b/src/utils/converter.ts
@@ -69,6 +69,13 @@ export async function convertToTailwindCSS(
   } catch {}
 
   try {
+    const id = nanoid();
+    const wrapped = wrapCSS(id, input);
+    const converted = await tailwindConverter.convertCSS(wrapped);
+    return converted.nodes.flatMap((node) => node.tailwindClasses).join(" ");
+  } catch {}
+
+  try {
     return (await tailwindConverter.convertCSS(input)).convertedRoot.toString();
   } catch (e) {
     Log.error(e);


### PR DESCRIPTION
# What

Allows selecting and converting css properties without a selector

https://github.com/Jackardios/vscode-css-to-tailwindcss/assets/2379652/2048399f-0688-4a7b-97f5-d80985308c1d

# Why

I can see prople having a use case where they just have a bunch of properites that they want to migrate.

For example: They think of a css property but do not know the tailwind class, they can write that property and get the tailwind class for that _in place_.

Another thing:

We are currently migrating our project from [emotion](https://emotion.sh/docs/introduction) to tailwind and emotion does not require css selectors. So we just have a bunch of css properties that we can now select and migrate as part of our workflow.