### PR TITLE
chore: Update the description of `cssToTailwindCss.arbitraryProperties to make it more understandable

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "cssToTailwindCss.arbitraryProperties": {
           "type": "boolean",
           "default": false,
-          "markdownDescription": "Defines whether non-convertible properties should be converted as 'arbitrary properties'."
+          "markdownDescription": "Convert CSS properties that Tailwind doesn't include a utility class for to 'arbitrary properties' using square bracket notation. Example: '*animation-delay: 200ms*' would be converted to '*[animation-delay:200ms]*'. This setting doesn't affect square bracket notation for existing utility classes."
         }
       }
     }


### PR DESCRIPTION
I've been quite confused by the "arbitrary properties" setting description, so I've updated it and added an example. I've also pointed out, that this setting doesn't affect the conversion of for example `color: #838741` to `text-[#838741]`, as this was quite confusing when I tried to change that setting and still saw square bracket notation being used.